### PR TITLE
fix: nvim configuration improvements

### DIFF
--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -9,8 +9,8 @@ vim.opt.number = true
 vim.opt.termguicolors = true
 vim.opt.scrolloff = 20
 vim.opt.clipboard = "unnamed"
-vim.opt.wrap = enabled
-vim.opt.spell = enabled
+vim.opt.wrap = true
+vim.opt.spell = true
 
 vim.cmd([[
   autocmd BufNewFile,BufRead *.csv set filetype=csv_semicolon
@@ -27,16 +27,16 @@ vim.api.nvim_create_autocmd("BufEnter", {
 vim.g.lazyvim_python_ruff = "ruff"
 
 -- Colorscheme and Lightline
--- vim.cmd("colorscheme nightfly")
--- vim.g.lightline = { colorscheme = "nightfly" }
--- vim.g.nightflyCursorColor = 1
+vim.cmd("colorscheme nightfly")
+vim.g.lightline = { colorscheme = "nightfly" }
+vim.g.nightflyCursorColor = 1
 --
 -- Run gofmt + goimports on save
 local format_sync_grp = vim.api.nvim_create_augroup("goimports", {})
 vim.api.nvim_create_autocmd("BufWritePre", {
 	pattern = "*.go",
 	callback = function()
-		require("go.format").goimports()
+		vim.lsp.buf.format()
 	end,
 	group = format_sync_grp,
 })

--- a/nvim/lua/plugins/vimplug.lua
+++ b/nvim/lua/plugins/vimplug.lua
@@ -129,9 +129,7 @@ return {
 		dependencies = {
 			{
 				"nvim-telescope/telescope-fzf-native.nvim",
-				build = (build_cmd ~= "cmake") and "make"
-					or "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build",
-				enabled = build_cmd ~= nil,
+				build = "make",
 				config = function(plugin)
 					LazyVim.on_load("telescope.nvim", function()
 						local ok, err = pcall(require("telescope").load_extension, "fzf")


### PR DESCRIPTION
## Summary

Applied recommendations from nvim configuration audit to fix critical issues and improve the setup.

## Changes

- **options.lua**: Fixed syntax errors (`enabled` → `true`) and activated nightfly colorscheme
- **options.lua**: Replaced direct `require("go.format")` with `vim.lsp.buf.format()` for proper LSP integration
- **vimplug.lua**: Simplified telescope-fzf-native build configuration

## Testing

- Syntax errors resolved
- Nightfly colorscheme now loads on startup
- Go formatting now uses native LSP formatter
- Telescope-fzf-native builds with simple make command